### PR TITLE
Make time to live configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Script and Docker container to update the IP address of a [gandi.net](https://ww
 - `UPDATE_INTERVAL`: time interval between updates (optional)
   - defaults to `1h` (one hour)
   - must be in [the format used by GNU `sleep`](https://www.gnu.org/software/coreutils/manual/html_node/sleep-invocation.html#sleep-invocation)
+- `TIME_TO_LIVE`: DNS TTL, in seconds, for the subdomain (optional)
+  - defaults to `3600` (one hour)
 
 ## Script
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Script and Docker container to update the IP address of a [gandi.net](https://ww
 - `UPDATE_INTERVAL`: time interval between updates (optional)
   - defaults to `1h` (one hour)
   - must be in [the format used by GNU `sleep`](https://www.gnu.org/software/coreutils/manual/html_node/sleep-invocation.html#sleep-invocation)
-- `TIME_TO_LIVE`: DNS TTL, in seconds, for the subdomain (optional)
+- `TIME_TO_LIVE`: DNS TTL, in seconds, for the record (optional)
   - defaults to `3600` (one hour)
 
 ## Script

--- a/gandi-dynamic-dns
+++ b/gandi-dynamic-dns
@@ -8,7 +8,7 @@ api_key="$GANDI_API_KEY"
 domain="$DOMAIN"
 record_name="$RECORD_NAME"
 update_interval="${UPDATE_INTERVAL:-1h}"
-timetolive="${TIME_TO_LIVE:-3600}"
+time_to_live="${TIME_TO_LIVE:-3600}"
 
 echo "updating domain '$domain' record '$record_name' every '$update_interval'"
 
@@ -28,7 +28,7 @@ update_ip() {
   request_data=$(cat <<EOF
 {
     "rrset_values": ["$ip"],
-    "rrset_ttl": $timetolive
+    "rrset_ttl": $time_to_live
 }
 EOF
 )

--- a/gandi-dynamic-dns
+++ b/gandi-dynamic-dns
@@ -8,13 +8,14 @@ api_key="$GANDI_API_KEY"
 domain="$DOMAIN"
 record_name="$RECORD_NAME"
 update_interval="${UPDATE_INTERVAL:-1h}"
+timetolive="${TIME_TO_LIVE:-3600}"
 
 echo "updating domain '$domain' record '$record_name' every '$update_interval'"
 
 previous_ip=
 
 update_ip() {
-  if ! ip="$(curl --fail --silent https://icanhazip.com)"; then
+  if ! ip="$(curl --fail --silent https://ipv4.icanhazip.com)"; then
     echo 'error: failed to get external IP address'
     return 1
   fi
@@ -26,7 +27,8 @@ update_ip() {
 
   request_data=$(cat <<EOF
 {
-    "rrset_values": ["$ip"]
+    "rrset_values": ["$ip"],
+    "rrset_ttl": $timetolive
 }
 EOF
 )


### PR DESCRIPTION
The environment variable `TIME_TO_LIVE` can now be used to override the default ttl for the DNS record.

Bugfix: ensures IP is IPV4